### PR TITLE
Provide JavaScript-encoded attributes

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,6 +1,7 @@
 {parse} = require './parser'
 cheerio = require 'cheerio'
 clone = require 'lodash.clone'
+jsesc = require 'jsesc'
 
 MIXINS = {
   likebutton: (data, {color, size}) ->
@@ -50,6 +51,42 @@ compile = (text, data = {}) ->
         v = true
 
     data[key] = v
+
+  # fix js-encoded variables
+  attrs = [
+    'Label',
+    'URL',
+    'Title',
+    'PostID',
+    'PostType',
+    'Quote',
+    'Source',
+    'LinkOpenTag',
+    'LinkCloseTag',
+    'PhotoAlt',
+    'Caption',
+    'Video-500',
+    'UserNumber',
+    'Name',
+    'Line',
+    'Body',
+    'AudioPlayer',
+    'PostNotes'
+  ]
+
+  if data?['block:Posts']?
+    for post in data['block:Posts']
+      for attr in attrs
+        console.log(attr, typeof post[attr], post[attr])
+
+        if typeof post[attr] != 'undefined'
+          value = post[attr]
+
+          post["JS#{attr}"] = jsesc(value, {
+            'lowercaseHex': true,
+            'quotes': 'single',
+            'wrap': true
+          })
 
   # fix up tumblr data
   if data?['block:Posts']?

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -77,8 +77,6 @@ compile = (text, data = {}) ->
   if data?['block:Posts']?
     for post in data['block:Posts']
       for attr in attrs
-        console.log(attr, typeof post[attr], post[attr])
-
         if typeof post[attr] != 'undefined'
           value = post[attr]
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "argparse": "^1.0.2",
     "cheerio": "^0.19.0",
+    "jsesc": "^2.4.0",
     "lodash.clone": "^3.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "parse",
     "compile"
   ],
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "main": "lib",
   "repository": "git://github.com/slang800/tumblr-theme-parser.git",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "devDependencies": {
     "coffee-script": "^1.9.2",
-    "mocha": "^2.2.4",
+    "mocha": "^3.2.0",
     "pegjs": "^0.8.0",
-    "should": "^6.0.1"
+    "should": "^11.2.1"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
I found that when working with JS-heavy themes ([React](https://facebook.github.io/react/), anyone?), this module comes quite short. As mentioned in #6, transformations of variables (`Plaintext`, `JavaScript`, ...) are missing, and I tried to resemble at least JavaScript-encoded variables.

This PR isn't done yet, but I'm interested in whether you'd like to include such a feature. What's still missing is...
* Tests
* Coverage of *all* JS-encodable variables
* Encoding of root-scope variables (e.g., `{JSTitle}`)